### PR TITLE
feat: GitHub Actions release workflow for cross-platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: xpia-defend
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: xpia-defend
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: xpia-defend
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: xpia-defend
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: xpia-defend.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux ARM64)
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (native)
+        if: "!matrix.cross"
+        run: cargo build --release --features cli --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --features cli --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../xpia-defend-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          7z a ../../../xpia-defend-${{ matrix.target }}.zip ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xpia-defend-${{ matrix.target }}
+          path: xpia-defend-${{ matrix.target }}.*
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect release assets
+        run: |
+          mkdir -p release-assets
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec mv {} release-assets/ \;
+          ls -la release-assets/
+
+      - name: Generate checksums
+        run: |
+          cd release-assets
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            release-assets/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds automatic binary release pipeline triggered on tag push (`v*`).

### Platforms
| Target | Runner | Method |
|--------|--------|--------|
| x86_64-unknown-linux-gnu | ubuntu-latest | native |
| aarch64-unknown-linux-gnu | ubuntu-latest | cross |
| x86_64-apple-darwin | macos-latest | native |
| aarch64-apple-darwin | macos-latest | native |
| x86_64-pc-windows-msvc | windows-latest | native |

### Release artifacts
- `xpia-defend-{target}.tar.gz` (Unix)
- `xpia-defend-{target}.zip` (Windows)
- `SHA256SUMS.txt` (checksums)

### Usage
```bash
git tag v0.1.0
git push origin v0.1.0
# → GitHub Release created with 5 platform binaries
```

Companion change in amplihack-rxp (PR #2992): auto-downloads the correct binary during `amplihack copilot` startup.