### PR TITLE
ci: harden supply chain — SHA-pin Actions, add cargo-deny gate, least-privilege tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
@@ -15,8 +18,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - run: cargo fmt --all --check
@@ -25,20 +28,20 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --all-targets --features cli -- -D warnings
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run unit + integration tests
         run: cargo test --lib --test adversarial --test outside_in --test golden_tests --features cli
       - name: Run CLI binary tests
@@ -48,9 +51,9 @@ jobs:
     name: Property Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run property-based tests
         run: cargo test --test property_tests
         timeout-minutes: 10
@@ -59,12 +62,22 @@ jobs:
     name: Build CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build --release --features cli
       - name: Smoke test binary
         run: |
           echo "test content" | ./target/release/xpia-defend validate-content --security-level medium
           ./target/release/xpia-defend health
           ./target/release/xpia-defend patterns | head -5
+
+  cargo-deny:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check
+          command-arguments: advisories bans licenses sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install cross (Linux ARM64)
         if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 29d00c7803f221f1b3f35e561b03792368fb8339 --locked # main @ 2026-06-06
 
       - name: Build (native)
         if: "!matrix.cross"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,9 +37,9 @@ jobs:
             artifact: xpia-defend.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -68,7 +68,7 @@ jobs:
           7z a ../../../xpia-defend-${{ matrix.target }}.zip ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: xpia-defend-${{ matrix.target }}
           path: xpia-defend-${{ matrix.target }}.*
@@ -77,11 +77,13 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
@@ -98,7 +100,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           files: |

--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,8 @@ confidence-threshold = 0.8
 [bans]
 # Surface duplicate dependency versions without failing the build.
 multiple-versions = "warn"
-wildcards = "allow"
+# Reject wildcard ("*") version requirements outright.
+wildcards = "deny"
 
 [sources]
 # Only crates.io is trusted; reject unknown registries and any git sources.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,34 @@
+# cargo-deny configuration — supply-chain audit gate.
+# Run locally with: cargo deny --all-features check advisories bans licenses sources
+# Schema targets cargo-deny 0.18+ (CI pins EmbarkStudios/cargo-deny-action).
+
+[graph]
+all-features = true
+
+[advisories]
+# Fail on security vulnerabilities and yanked crates (defaults).
+# Add advisory IDs here with a justification only if an upstream fix is
+# unavailable; prefer upgrading the dependency instead.
+ignore = []
+
+[licenses]
+# Allow-list limited to the licenses actually present in the dependency tree.
+# Do not blanket-allow — add a license here only after confirming a crate uses it.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Unicode-3.0",
+    "MPL-2.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+# Surface duplicate dependency versions without failing the build.
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+# Only crates.io is trusted; reject unknown registries and any git sources.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Supply-chain hardening for `amplihack-xpia-defender`

Hardens the two GitHub Actions workflows and adds a dependency-audit gate.
**Config/CI-only change — no Rust source touched.**

### What changed

1. **SHA-pin every GitHub Action** in `ci.yml` and `release.yml` to a full
   40-char commit SHA with a trailing `# vX.Y.Z` comment, removing reliance on
   mutable tags (a tag can be re-pointed at malicious code):

   | Action | Pinned SHA | Version |
   | --- | --- | --- |
   | `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
   | `dtolnay/rust-toolchain` | `29eef336d9b2848a0b548edc03f92a220660cdb8` | stable branch |
   | `Swatinem/rust-cache` | `c19371144df3bb44fab255c43d04cbc2ab54d1c4` | v2.9.1 |
   | `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
   | `actions/download-artifact` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4.3.0 |
   | `softprops/action-gh-release` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |
   | `EmbarkStudios/cargo-deny-action` | `bb137d7af7e4fb67e5f82a49c4fce4fad40782fe` | v2.0.20 |

   `dtolnay/rust-toolchain` is pinned to the `stable` branch's current commit,
   whose `action.yml` defaults `toolchain: stable`, so existing `with:` blocks
   (`components`, `targets`) keep working unchanged. The pin freezes the
   *action*, not the Rust version — `rustup` still installs the latest stable
   at runtime, as intended.

   Also pinned the non-Action build tool: the aarch64 release job installed
   `cross` from the **mutable** `cross-rs/cross` default-branch HEAD; it is now
   pinned to an immutable commit with `--locked`
   (`--rev 29d00c78… --locked`), closing the same class of hole for build
   tooling.

2. **Dependency-audit gate** — new `deny.toml` + a `cargo-deny` job in `ci.yml`
   running `cargo deny check advisories bans licenses sources` via the
   SHA-pinned cargo-deny-action. The license allow-list is restricted to the
   licenses actually present in the resolved tree (no blanket allow):
   `MIT`, `Apache-2.0`, `Unicode-3.0`, `MPL-2.0`. `[sources]` restricts to
   crates.io and denies unknown registries / git sources; `[bans] wildcards`
   is set to `deny`.

3. **Least-privilege `GITHUB_TOKEN`**:
   - `ci.yml`: adds top-level `permissions: contents: read`.
   - `release.yml`: drops repo-wide top-level `contents: write` to
     `contents: read`; `contents: write` is now scoped to **only** the
     `release` job that publishes the GitHub Release. The `build` job inherits
     read-only (artifact upload/download use the Actions runtime token).

4. **Dependencies locked**: `Cargo.lock` remains committed (unchanged).
   `Cargo.toml` has no `git = …` dependencies, so there is nothing to rev-pin.

### Merge-ready evidence

**(1) QA / validation** — `gadugi-test` is a Simard-internal harness that does
not apply to this external Rust crate's CI config, and no Rust source changed.
Equivalent validation for a workflow/supply-chain change:
  - `actionlint 1.7.12` on both workflows: clean. (The single pre-existing
    SC2035 info note on the unmodified `sha256sum *` checksums step is not
    introduced here and is left untouched to keep the diff focused.)
  - `python3 yaml.safe_load`: both workflows parse as valid YAML.
  - `cargo deny --all-features check advisories bans licenses sources`
    (local cargo-deny 0.19.9; CI action bundles 0.19.8, same schema):
    `advisories ok, bans ok, licenses ok, sources ok`.
  - **Live CI 100% green** (run
    [28412639730](https://github.com/rysweet/amplihack-xpia-defender/actions/runs/28412639730)):
    Format, Clippy, Test, Property Tests, Build CLI, **Dependency Audit**, and
    GitGuardian all pass.

**(2) Docs** — no user-facing surface changed. Changed surfaces are limited to
`.github/workflows/ci.yml`, `.github/workflows/release.yml`, and new
`deny.toml` (CI/internal config). Internal-only; no docs update required.

**(3) Quality cycles** — 3 SEEK→VALIDATE→FIX cycles, ending clean:
  - **Cycle 1** (code-review @ `127623f`): no significant issues; all SHA
    pins, `rust-toolchain` behavior, cargo-deny job, least-privilege, and
    `deny.toml` verified sound.
  - **Cycle 2** (security-review @ `127623f`): one **MEDIUM** finding — `cross`
    installed from mutable HEAD — plus a minor `wildcards` suggestion. No
    other issues; no injection / `pull_request_target` / secret-exposure risk.
  - **FIX** (`320a424`): pinned `cross` to `--rev 29d00c78… --locked`;
    set `[bans] wildcards = "deny"`. Re-validated: `cargo deny` all ok.
  - **Cycle 3 / final** (code-review @ `320a424`): **clean — zero
    critical/high/medium** correctness or security findings; all 22 `uses:`
    SHA-pinned, permissions least-privilege, diff focused.

**(4) CI** — 100% green, 0 failures: run
[28412639730](https://github.com/rysweet/amplihack-xpia-defender/actions/runs/28412639730),
including the new `cargo-deny` **Dependency Audit** job.

**(6) Diff focused** — 3 files (`ci.yml`, `release.yml`, `deny.toml`). Only
Actions/tool pinning, the audit gate, and token-permission scoping. No
unrelated edits.
