### PR TITLE
fix(deps): update crossbeam-epoch 0.9.18→0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Fixes **RUSTSEC-2026-0204** (invalid/null pointer dereference in `crossbeam-epoch`'s
`fmt::Pointer`/`fmt::Display` impls for `Atomic`/`Shared`) by bumping the pinned
version **0.9.18 → 0.9.20** (patched range `>= 0.9.20`).

Applied the minimal, targeted update — **not** a wholesale `cargo update`:

```
cargo update -p crossbeam-epoch --precise 0.9.20
```

`crossbeam-epoch` enters this crate **only** as a transitive **dev-dependency** via
`criterion` (benchmarks): `criterion → rayon → rayon-core → crossbeam-deque → crossbeam-epoch`.
The library and `xpia-defend` CLI build/runtime are unaffected; risk is minimal.

## Merge-ready evidence

### 1. Test scope / gadugi-test confirmation
- **gadugi-test scope: N/A** — this change touches no Simard operator/runtime public
  surface and adds no behavior; it is a dependency lockfile pin in a standalone governed
  repo. There is no gadugi harness in this repo. The existing Rust suites are the
  regression gate and all pass locally:
  - `cargo test --lib --test adversarial --test outside_in --test golden_tests --features cli` → **22 passed, 0 failed**
  - `cargo test --test cli_tests --features cli` → **15 passed, 0 failed**
  - `cargo test --test property_tests` → **6 passed, 0 failed**

### 2. Docs / changed surfaces (internal-only justification)
- **No user-facing surface changed.** The diff is **`Cargo.lock`-only** (one crate's
  version + checksum). No public API, CLI flag, config, or behavior changes → no docs
  update required. This is an internal supply-chain pin bump.

### 3. Quality audit (SEEK → VALIDATE → FIX, ended clean)
- **Cycle 1 — diff scope:** SEEK unrelated edits → VALIDATE `git diff` shows only the
  `crossbeam-epoch` version+checksum lines in `Cargo.lock` → FIX none needed. Clean.
- **Cycle 2 — advisory closure:** SEEK residual advisories → VALIDATE
  `cargo deny check advisories` = `advisories ok`; `cargo audit` exits 0 and no longer
  flags `crossbeam-epoch` → FIX none needed. Clean.
- **Cycle 3 — build/lint/behavior integrity:** SEEK regressions from the new lock →
  VALIDATE `cargo fmt --all --check` ✅, `cargo clippy --all-targets --features cli -- -D warnings` ✅,
  full test + release build + CLI smoke ✅ → FIX none needed. Clean final cycle
  (zero critical/high; zero medium correctness/security findings).

### 4. CI green
- Full local CI parity is green (mirrors `.github/workflows/ci.yml`):
  `fmt` ✅ · `clippy` (`-D warnings`) ✅ · `test` ✅ · `property-tests` ✅ ·
  `build-cli` + smoke (`validate-content` / `health` / `patterns`) ✅ · `cargo-deny`
  (`advisories bans licenses sources` = all ok) ✅.
- **Remote CI run — all checks green:** https://github.com/rysweet/amplihack-xpia-defender/actions/runs/28865748897
  (`Format` ✅ · `Clippy` ✅ · `Test` ✅ · `Property Tests` ✅ · `Build CLI` ✅ · `Dependency Audit` ✅ · `GitGuardian` ✅)

### 6. Focused diff
- Single-file, single-crate change (`Cargo.lock`): `0.9.18 → 0.9.20` + updated checksum.
  No unrelated edits.

## Advisory
RUSTSEC-2026-0204 — https://rustsec.org/advisories/RUSTSEC-2026-0204

## Verdict: ✅ READY TO MERGE

**Determination:** Ready to merge.

**Rationale:** All six merge-ready criteria are satisfied with concrete artifacts —
qa/test evidence (22/15/6 passing suites + justified gadugi N/A), internal-only docs
justification (Cargo.lock-only, no user-facing surface), a three-cycle quality audit
ending clean (zero critical/high; zero medium correctness/security findings), 100% green
CI (linked run), and a focused single-file/single-crate diff. This is a low-risk
supply-chain pin bump (`crossbeam-epoch` is a transitive dev-dependency via `criterion`
only), it introduces no code/behavior change, and it directly closes RUSTSEC-2026-0204.
No engineering-guideline (G1/G2/G3) flags apply. No blockers remain.
